### PR TITLE
Fix typo, doc, bug and improve test

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project offers two types of interfaces:
 
 ## Notes
 
-Due to the ongoing development of the Moonbit language and its build system, this project is still under testing phrase, using this project may currently involve some complexity, and issues such as linking errors or memory leaks may occur. We are actively addressing these issues and improving the experience as the Moonbit compiler evolves. We look forward to delivering an exceptional LLVM development experience with future versions of Moonbit and Moonbit-LLVM.
+Due to the ongoing development of the Moonbit language and its build system, this project is still under testing phase, using this project may currently involve some complexity, and issues such as linking errors or memory leaks may occur. We are actively addressing these issues and improving the experience as the Moonbit compiler evolves. We look forward to delivering an exceptional LLVM development experience with future versions of Moonbit and Moonbit-LLVM.
 
 ## Quick Start
 

--- a/llvm/basic_block.mbt
+++ b/llvm/basic_block.mbt
@@ -103,7 +103,7 @@ pub fn BasicBlock::get_previous_basic_block(self : BasicBlock) -> BasicBlock? {
 pub fn BasicBlock::get_next_basic_block(self : BasicBlock) -> BasicBlock? {
   let next_bb_ref = @unsafe.llvm_get_next_basic_block(self.as_bb_ref())
   @option.when(next_bb_ref.is_not_null(), fn() {
-    BasicBlock::new(@unsafe.llvm_get_next_basic_block(self.as_bb_ref()))
+    BasicBlock::new(next_bb_ref)
   })
 }
 
@@ -401,9 +401,9 @@ pub fn BasicBlock::set_name(self : BasicBlock, name : String) -> Unit {
 /// let void_type = context.void_type();
 /// let fn_type = void_type.fn_type([]);
 /// let fn_val = llvm_module.add_function("my_fn", fn_type);
-/// let entry = context.append_basic_block(fn_val, content="entry");
-/// let bb1 = context.append_basic_block(fn_val, content="bb1");
-/// let bb2 = context.append_basic_block(fn_val, content="bb2");
+/// let entry = context.append_basic_block(fn_val, name="entry");
+/// let bb1 = context.append_basic_block(fn_val, name="bb1");
+/// let bb2 = context.append_basic_block(fn_val, name="bb2");
 /// builder.position_at_end(entry);
 /// let branch_inst = builder.build_unconditional_branch(bb1).unwrap();
 ///
@@ -433,9 +433,9 @@ pub fn BasicBlock::replace_all_uses_with(
 /// let void_type = context.void_type();
 /// let fn_type = void_type.fn_type([]);
 /// let fn_val = llvm_module.add_function("my_fn", fn_type);
-/// let entry = context.append_basic_block(fn_val, content="entry");
-/// let bb1 = context.append_basic_block(fn_val, content="bb1");
-/// let bb2 = context.append_basic_block(fn_val, content="bb2");
+/// let entry = context.append_basic_block(fn_val, name="entry");
+/// let bb1 = context.append_basic_block(fn_val, name="bb1");
+/// let bb2 = context.append_basic_block(fn_val, name="bb2");
 /// builder.position_at_end(entry);
 /// let branch_inst = builder.build_unconditional_branch(bb1);
 ///
@@ -460,8 +460,8 @@ pub fn BasicBlock::get_first_use(self : BasicBlock) -> BasicValueUse? {
 /// let void_type = context.void_type();
 /// let fn_type = void_type.fn_type([]);
 /// let fn_val = llvm_module.add_function("my_fn", fn_type);
-/// let entry_bb = context.append_basic_block(fn_val, content="entry");
-/// let next_bb = context.append_basic_block(fn_val, content="next");
+/// let entry_bb = context.append_basic_block(fn_val, name="entry");
+/// let next_bb = context.append_basic_block(fn_val, name="next");
 ///
 /// assert_true(entry_bb.get_address() is None);
 /// assert_true(next_bb.get_address() is Some(_));

--- a/llvm/global_value.mbt
+++ b/llvm/global_value.mbt
@@ -49,7 +49,7 @@ pub fn GlobalValue::get_next_global(self : GlobalValue) -> GlobalValue? {
 }
 
 ///|
-pub fn GlobalValue::get_dll_storge_class(self : GlobalValue) -> DLLStorageClass {
+pub fn GlobalValue::get_dll_storage_class(self : GlobalValue) -> DLLStorageClass {
   let dc = @unsafe.llvm_get_dll_storage_class(self.as_value_ref())
   DLLStorageClass::from(dc)
 }

--- a/test/basic_block_test.mbt
+++ b/test/basic_block_test.mbt
@@ -25,11 +25,15 @@ test "Basic Block Test" {
   bb2.move_before(bb1)
   assert_true(bb1.get_next_basic_block() is None)
   assert_true(bb2.get_next_basic_block().unwrap() == bb1)
+  assert_true(bb2.get_previous_basic_block() is None)
+  assert_true(bb1.get_previous_basic_block().unwrap() == bb2)
 
   // move_after
   bb2.move_after(bb1)
   assert_true(bb1.get_next_basic_block().unwrap() == bb2)
   assert_true(bb2.get_next_basic_block() is None)
+  assert_true(bb1.get_previous_basic_block() is None)
+  assert_true(bb2.get_previous_basic_block().unwrap() == bb1)
   let builder = context.create_builder()
   builder.position_at_end(bb1)
 


### PR DESCRIPTION
## Summary
- fix `testing phase` typo in README
- rename `get_dll_storage_class` API
- fix next basic block retrieval
- correct example comments for append_basic_block
- add assertions to BasicBlock test

## Testing
- `moon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0af7dfdc8331b106beb9fc5dfad8