### PR TITLE
Fix typos in public API names

### DIFF
--- a/llvm/builder.mbt
+++ b/llvm/builder.mbt
@@ -1095,7 +1095,7 @@ pub fn Builder::build_memcpy(
 /// The final argument should be a pointer-sized integer.
 ///
 /// Returns an `Err(BuilderError::AlignmentError)` if the source or destination alignments are not a power of 2 under 2^64.
-pub fn Builder::build_memove(
+pub fn Builder::build_memmove(
   self : Builder,
   dest : PointerValue,
   dst_align : UInt,

--- a/llvm/global_value.mbt
+++ b/llvm/global_value.mbt
@@ -49,7 +49,7 @@ pub fn GlobalValue::get_next_global(self : GlobalValue) -> GlobalValue? {
 }
 
 ///|
-pub fn GlobalValue::get_dll_storge_class(self : GlobalValue) -> DLLStorageClass {
+pub fn GlobalValue::get_dll_storage_class(self : GlobalValue) -> DLLStorageClass {
   let dc = @unsafe.llvm_get_dll_storage_class(self.as_value_ref())
   DLLStorageClass::from(dc)
 }

--- a/llvm/inst_value.mbt
+++ b/llvm/inst_value.mbt
@@ -621,7 +621,7 @@ pub fn InstructionValue::set_operand(
 ///
 /// assert_eq(store_instruction.get_operand_use(1), arg1.get_first_use());
 /// ```
-pub fn InstructionValue::get_oprand_use(
+pub fn InstructionValue::get_operand_use(
   self : InstructionValue,
   index : UInt
 ) -> BasicValueUse? {
@@ -629,11 +629,11 @@ pub fn InstructionValue::get_oprand_use(
   if index >= num_operands {
     return None
   }
-  self.get_oprand_use_unchecked(index)
+  self.get_operand_use_unchecked(index)
 }
 
 ///|
-fn InstructionValue::get_oprand_use_unchecked(
+fn InstructionValue::get_operand_use_unchecked(
   self : InstructionValue,
   index : UInt
 ) -> BasicValueUse? {
@@ -642,7 +642,7 @@ fn InstructionValue::get_oprand_use_unchecked(
 }
 
 // TODO: should return array or iter?
-// pub fn InstructionValue::get_oprand_uses(self: InstructionValue) ->
+// pub fn InstructionValue::get_operand_uses(self: InstructionValue) ->
 
 ///| Gets the first use of an `InstructionValue` if any.
 ///


### PR DESCRIPTION
## Summary
- rename `build_memove` to `build_memmove`
- rename `get_dll_storge_class` to `get_dll_storage_class`
- rename `get_oprand_use` helpers to `get_operand_use`

## Testing
- `cargo --version`
- `moon --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0af830608331b9a042fa6535f568