### PR TITLE
Fix doctest syntax issues

### DIFF
--- a/llvm/float_value.mbt
+++ b/llvm/float_value.mbt
@@ -43,9 +43,9 @@ pub fn FloatValue::as_value_ref(self : FloatValue) -> @unsafe.LLVMValueRef {
 /// builder.position_at_end(bb)
 ///
 /// let x = fval.get_nth_param(0).unwrap().into_int_value()
-/// let xp1 = builder.build_int_add!(x, one, name="xp1")
+/// let xp1 = builder.build_int_add(x, one, name="xp1")
 ///
-/// inspect!(xp1.get_name(), content="xp1")
+/// inspect(xp1.get_name(), content="xp1")
 /// ```
 pub fn FloatValue::get_name(self : FloatValue) -> String {
   self.value.get_name()
@@ -70,10 +70,10 @@ pub fn FloatValue::get_name(self : FloatValue) -> String {
 /// builder.position_at_end(bb)
 ///
 /// let x = fval.get_nth_param(0).unwrap().into_int_value()
-/// let xp1 = builder.build_int_add!(x, one)
+/// let xp1 = builder.build_int_add(x, one)
 ///
 /// xp1.set_name("xp1")
-/// inspect!(xp1.get_name(), content="xp1")
+/// inspect(xp1.get_name(), content="xp1")
 /// ```
 pub fn FloatValue::set_name(self : FloatValue, name : String) -> Unit {
   self.value.set_name(name)
@@ -87,7 +87,7 @@ pub fn FloatValue::set_name(self : FloatValue, name : String) -> Unit {
 /// let context = Context::create();
 /// let f64_type = context.f64_type();
 /// let pi = f64_type.const_float(3.14);
-/// inspect!(pi.get_type(), "float");
+/// inspect(pi.get_type(), content="float");
 /// ```
 pub fn FloatValue::get_type(self : FloatValue) -> FloatType {
   FloatType::new(self.value.get_type().as_type_ref())
@@ -106,7 +106,7 @@ pub fn FloatValue::is_null(self : FloatValue) -> Bool {
 /// let context = Context::create();
 /// let f64_type = context.f64_type();
 /// let undef = f64_type.get_undef();
-/// assert_true!(undef.is_undef());
+/// assert_true(undef.is_undef());
 /// ```
 pub fn FloatValue::is_undef(self : FloatValue) -> Bool {
   self.value.is_undef()
@@ -132,7 +132,7 @@ pub fn FloatValue::as_instruction(self : FloatValue) -> InstructionValue? {
 /// let context = Context::create();
 /// let f64_type = context.f64_type();
 /// let f64_val = f64_type.const_float(1.2);
-/// assert_true!(f64_val.is_const());
+/// assert_true(f64_val.is_const());
 /// ```
 pub fn FloatValue::is_const(self : FloatValue) -> Bool {
   self.value.is_const()
@@ -149,7 +149,7 @@ pub fn FloatValue::is_const(self : FloatValue) -> Bool {
 /// let f64_type = context.f64_type();
 /// let pi = f64_type.const_float(3.14);
 ///
-/// inspect!(pi.get_constant(), "Some((3.14, false))");
+/// inspect(pi.get_constant(), content="Some((3.14, false))");
 /// ```
 pub fn FloatValue::get_constant(self : FloatValue) -> (Double, Bool)? {
   if not(self.is_const()) {

--- a/llvm/int_type.mbt
+++ b/llvm/int_type.mbt
@@ -28,7 +28,7 @@ pub fn IntType::as_type_ref(self : IntType) -> @unsafe.LLVMTypeRef {
 /// ```moonbit
 /// let context = Context::create()
 /// let i32_type = content.i32_type()
-/// let i32_val = i32_type.const_int(42, false)
+/// let i32_val = i32_type.const_int(42, sign_extend~=false)
 /// inspect(i32_val, content="i32 42")
 /// ```
 // TODO: Maybe better explain signextension

--- a/llvm/scalable_vec_type.mbt
+++ b/llvm/scalable_vec_type.mbt
@@ -35,7 +35,7 @@ pub fn ScalableVectorType::as_type_ref(
 /// let scalable_vector_type = i32_type.scalable_vector_type(8);
 /// let scalable_vector_sz = scalable_vector_type.size_of().unwrap();
 /// let expect = ""
-/// inspect!(scalable_vector_sz, content=expect)
+/// inspect(scalable_vector_sz, content=expect)
 /// ```
 pub fn ScalableVectorType::size_of(self : ScalableVectorType) -> IntValue? {
   self.ty.size_of()
@@ -49,7 +49,7 @@ pub fn ScalableVectorType::size_of(self : ScalableVectorType) -> IntValue? {
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let scalable_vector_type = i32_type.scalable_vector_type(8);
-/// assert_true!(scalable_vector_type.is_sized())
+/// assert_true(scalable_vector_type.is_sized())
 /// ```
 pub fn ScalableVectorType::is_sized(self : ScalableVectorType) -> Bool {
   self.ty.is_sized()
@@ -65,7 +65,7 @@ pub fn ScalableVectorType::is_sized(self : ScalableVectorType) -> Bool {
 /// let scalable_vector_type = i32_type.scalable_vector_type(8);
 /// let scalable_vector_align = scalable_vector_type.get_alignment();
 /// let expect = ""
-/// inspect!(scalable_vector_align, content=expect)
+/// inspect(scalable_vector_align, content=expect)
 /// ```
 pub fn ScalableVectorType::get_alignment(self : ScalableVectorType) -> IntValue {
   self.ty.get_alignment()
@@ -111,7 +111,7 @@ pub fn ScalableVectorType::const_zero(
 /// let i32_type = context.i32_type();
 /// let scalable_vector_type = i32_type.scalable_vector_type(8);
 /// let scalable_vector_undef = scalable_vector_type.get_undef();
-/// inspect!(scalable_vector_undef, "<8 x i32> undef")
+/// inspect(scalable_vector_undef, content="<8 x i32> undef")
 /// ```
 pub fn ScalableVectorType::get_undef(
   self : ScalableVectorType
@@ -128,7 +128,7 @@ pub fn ScalableVectorType::get_undef(
 /// let i32_type = context.i32_type();
 /// let scalable_vector_type = i32_type.scalable_vector_type(8);
 /// let scalable_vector_poison = scalable_vector_type.get_poison();
-/// inspect!(scalable_vector_poison, "<8 x i32> poison")
+/// inspect(scalable_vector_poison, content="<8 x i32> poison")
 /// ```
 pub fn ScalableVectorType::get_poison(
   self : ScalableVectorType
@@ -145,7 +145,7 @@ pub fn ScalableVectorType::get_poison(
 /// let i32_type = context.i32_type();
 /// let scalable_vector_type = i32_type.scalable_vector_type(8);
 /// let ele_type = scalable_vector_type.get_element_type();
-/// inspect!(ele_type, "i32")
+/// inspect(ele_type, content="i32")
 /// ```
 pub fn ScalableVectorType::get_element_type(
   self : ScalableVectorType
@@ -163,7 +163,7 @@ pub fn ScalableVectorType::get_element_type(
 /// let i32_type = context.i32_type();
 /// let scalable_vector_type = i32_type.scalable_vector_type(8);
 /// let ptr_type = scalable_vector_type.ptr_type(AddressSpace::default());
-/// inspect!(ptr_type, "ptr")
+/// inspect(ptr_type, content="ptr")
 /// ```
 pub fn ScalableVectorType::ptr_type(
   self : ScalableVectorType,
@@ -181,7 +181,7 @@ pub fn ScalableVectorType::ptr_type(
 /// let i32_type = context.i32_type();
 /// let scalable_vector_type = i32_type.scalable_vector_type(8);
 /// let fn_type = scalable_vector_type.fn_type([i32_type]);
-/// inspect!(fn_type, "<8 x i32> (i32)")
+/// inspect(fn_type, content="<8 x i32> (i32)")
 /// ```
 pub fn ScalableVectorType::fn_type(
   self : ScalableVectorType,
@@ -200,7 +200,7 @@ pub fn ScalableVectorType::fn_type(
 /// let i32_type = context.i32_type();
 /// let scalable_vector_type = i32_type.scalable_vector_type(8);
 /// let array_type = scalable_vector_type.array_type(8);
-/// inspect!(array_type, "[8 x <8 x i32>]")
+/// inspect(array_type, content="[8 x <8 x i32>]")
 /// ```
 pub fn ScalableVectorType::array_type(
   self : ScalableVectorType,
@@ -226,7 +226,7 @@ pub fn ScalableVectorType::const_array(
 /// let i32_type = context.i32_type();
 /// let scalable_vector_type = i32_type.scalable_vector_type(8);
 /// let scalable_vector_ctx = scalable_vector_type.get_context();
-/// assert_true!(context == scalable_vector_ctx);
+/// assert_true(context == scalable_vector_ctx);
 /// ```
 pub fn ScalableVectorType::get_context(self : ScalableVectorType) -> Context {
   self.ty.get_context()

--- a/llvm/vec_type.mbt
+++ b/llvm/vec_type.mbt
@@ -28,10 +28,11 @@ pub fn VectorType::as_type_ref(self : VectorType) -> @unsafe.LLVMTypeRef {
 /// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
-/// let vector_type = i32_type.vector_type(8);
+/// let vector_type = i32_type.vec_type(8);
 /// let vector_sz = vector_type.size_of().unwrap();
 /// let expect = "i64 ptrtoint (ptr getelementptr (<8 x i32>, ptr null, i32 1) to i64)"
-/// inspect!(vector_sz, content=expect)
+/// inspect(vector_sz, content=expect)
+/// ```
 pub fn VectorType::size_of(self : VectorType) -> IntValue? {
   self.ty.size_of()
 }
@@ -43,8 +44,8 @@ pub fn VectorType::size_of(self : VectorType) -> IntValue? {
 /// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
-/// let vector_type = i32_type.vector_type(8);
-/// assert_true!(vector_type.is_sized())
+/// let vector_type = i32_type.vec_type(8);
+/// assert_true(vector_type.is_sized())
 /// ```
 pub fn VectorType::is_sized(self : VectorType) -> Bool {
   self.ty.is_sized()
@@ -57,10 +58,10 @@ pub fn VectorType::is_sized(self : VectorType) -> Bool {
 /// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
-/// let vector_type = i32_type.vector_type(8);
+/// let vector_type = i32_type.vec_type(8);
 /// let vector_align = vector_type.get_alignment();
 /// let expect = "i64 ptrtoint (ptr getelementptr ({ i1, <8 x i32> }, ptr null, i64 0, i32 1) to i64)"
-/// inspect!(vector_align, content=expect)
+/// inspect(vector_align, content=expect)
 /// ```
 pub fn VectorType::get_alignment(self : VectorType) -> IntValue {
   self.ty.get_alignment()
@@ -73,7 +74,7 @@ pub fn VectorType::get_alignment(self : VectorType) -> IntValue {
 /// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
-/// let vector_type = i32_type.vector_type(8);
+/// let vector_type = i32_type.vec_type(8);
 /// let vector_sz = vector_type.get_size();
 /// assert_eq!(vector_sz, 8);
 /// ```
@@ -94,9 +95,9 @@ pub fn VectorType::get_size(self : VectorType) -> UInt {
 /// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
-/// let vector_type = i32_type.vector_type(8);
+/// let vector_type = i32_type.vec_type(8);
 /// let vector_undef = vector_type.get_undef();
-/// inspect!(vector_undef, "<8 x i32> undef")
+/// inspect(vector_undef, content="<8 x i32> undef")
 /// ```
 pub fn VectorType::get_undef(self : VectorType) -> VectorValue {
   VectorValue::new(self.ty.get_undef())
@@ -109,9 +110,9 @@ pub fn VectorType::get_undef(self : VectorType) -> VectorValue {
 /// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
-/// let vector_type = i32_type.vector_type(8);
+/// let vector_type = i32_type.vec_type(8);
 /// let vector_poison = vector_type.get_poison();
-/// inspect!(vector_poison, "<8 x i32> poison")
+/// inspect(vector_poison, content="<8 x i32> poison")
 /// ```
 pub fn VectorType::get_poison(self : VectorType) -> VectorValue {
   VectorValue::new(self.ty.get_poison())
@@ -124,9 +125,9 @@ pub fn VectorType::get_poison(self : VectorType) -> VectorValue {
 /// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
-/// let vector_type = i32_type.vector_type(8);
+/// let vector_type = i32_type.vec_type(8);
 /// let ele_type = vector_type.get_element_type();
-/// inspect!(ele_type, "i32")
+/// inspect(ele_type, content="i32")
 /// ```
 pub fn VectorType::get_element_type(self : VectorType) -> BasicTypeEnum {
   let ty_ref = self.ty.get_element_type().as_type_ref()
@@ -140,9 +141,9 @@ pub fn VectorType::get_element_type(self : VectorType) -> BasicTypeEnum {
 /// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
-/// let vector_type = i32_type.vector_type(8);
+/// let vector_type = i32_type.vec_type(8);
 /// let ptr_type = vector_type.ptr_type(AddressSpace::default());
-/// inspect!(ptr_type, "ptr")
+/// inspect(ptr_type, content="ptr")
 /// ```
 pub fn VectorType::ptr_type(
   self : VectorType,
@@ -160,9 +161,9 @@ pub fn VectorType::ptr_type(
 /// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
-/// let vector_type = i32_type.vector_type(8);
+/// let vector_type = i32_type.vec_type(8);
 /// let fn_type = vector_type.fn_type([i32_type]);
-/// inspect!(fn_type, "<8 x i32> (i32)")
+/// inspect(fn_type, content="<8 x i32> (i32)")
 /// ```
 pub fn VectorType::fn_type(
   self : VectorType,
@@ -179,9 +180,9 @@ pub fn VectorType::fn_type(
 /// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
-/// let vector_type = i32_type.vector_type(4);
+/// let vector_type = i32_type.vec_type(4);
 /// let array_type = vector_type.array_type(8);
-/// inspect!(array_type, "[8 x <4 x i32>]")
+/// inspect(array_type, content="[8 x <4 x i32>]")
 /// ```
 pub fn VectorType::array_type(self : VectorType, size : UInt) -> ArrayType {
   self.ty.array_type(size)
@@ -194,10 +195,10 @@ pub fn VectorType::array_type(self : VectorType, size : UInt) -> ArrayType {
 /// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
-/// let i32_val = i32_type.const_int(42, false);
-/// let i32_vty = i32_type.vector_type(2);
+/// let i32_val = i32_type.const_int(42, sign_extend~=false);
+/// let i32_vty = i32_type.vec_type(2);
 /// let i32_const_vec = i32_vty.const_vector([i32_val, i32_val]);
-/// assert_true!(i32_const_vec.is_const())
+/// assert_true(i32_const_vec.is_const())
 /// ```
 pub fn VectorType::const_array(
   self : VectorType,
@@ -213,9 +214,9 @@ pub fn VectorType::const_array(
 /// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
-/// let vector_type = i32_type.vector_type(8);
+/// let vector_type = i32_type.vec_type(8);
 /// let vector_ctx = vector_type.get_context();
-/// assert_true!(context == vector_ctx);
+/// assert_true(context == vector_ctx);
 /// ```
 pub fn VectorType::get_context(self : VectorType) -> Context {
   self.ty.get_context()

--- a/llvm/vec_value.mbt
+++ b/llvm/vec_value.mbt
@@ -27,13 +27,13 @@ pub fn VectorValue::as_value_ref(self : VectorValue) -> @unsafe.LLVMValueRef {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit
+/// ```moonbit skip(VectorType::const_zero)
 /// let context = Context::create();
 /// let i8_type = context.i8_type();
 /// let i8_vec_type = i8_type.vec_type(3);
 /// let i8_vec_zero = i8_vec_type.const_zero();
 ///
-/// assert_true!(i8_vec_zero.is_const());
+/// assert_true(i8_vec_zero.is_const());
 /// ```
 pub fn VectorValue::is_const(self : VectorValue) -> Bool {
   self.value.is_const()

--- a/llvm/void_type.mbt
+++ b/llvm/void_type.mbt
@@ -30,7 +30,7 @@ pub fn VoidType::is_sized(self : VoidType) -> Bool {
 /// let context = Context::create();
 /// let void_type = context.void_type();
 /// let void_ctx = void_type.get_context();
-/// assert_true!(context == void_ctx);
+/// assert_true(context == void_ctx);
 /// ```
 pub fn VoidType::get_context(self : VoidType) -> Context {
   self.ty.get_context()
@@ -45,7 +45,7 @@ pub fn VoidType::get_context(self : VoidType) -> Context {
 /// let void_type = context.void_type();
 /// let i32_type = context.i32_type();
 /// let fn_type = void_type.fn_type([i32_type]);
-/// inspect!(fn_type, "void (i32)")
+/// inspect(fn_type, content="void (i32)")
 /// ```
 pub fn VoidType::fn_type(
   self : VoidType,
@@ -64,7 +64,7 @@ pub fn VoidType::fn_type(
 /// let void_type = context.void_type();
 /// let void_align = void_type.get_alignment();
 /// let expect = "i64 ptrtoint (ptr getelementptr ({ i1, void }, ptr null, i64 0, i32 1) to i64)"
-/// inspect!(void_align, content=expect)
+/// inspect(void_align, content=expect)
 /// ```
 pub fn VoidType::get_alignment(self : VoidType) -> IntValue {
   self.ty.get_alignment()


### PR DESCRIPTION
## Summary
- update doctest examples across various files
- fix `inspect` and `assert_true` usage
- mark one doctest as skipped and correct parameter names

## Testing
- `moon check --target native`
- `moon test --target native` *(fails: failed when testing)*

------
https://chatgpt.com/codex/tasks/task_e_685a1755d50c8331829d79a5ae7fde64