### PR TITLE
Remove skip markers from runnable examples

### DIFF
--- a/llvm/arr_value.mbt
+++ b/llvm/arr_value.mbt
@@ -76,7 +76,7 @@ pub fn ArrayValue::replace_all_uses_with(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i64_type = context.i64_type();
 /// let i64_val = i64_type.const_int(23);
@@ -91,7 +91,7 @@ pub fn ArrayValue::is_const(self : ArrayValue) -> Bool {
 ///
 /// # Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let s = context.const_string("my_string", false);
 ///
@@ -107,7 +107,7 @@ pub fn ArrayValue::is_const_string(self : ArrayValue) -> Bool {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let string = context.const_string("hello!", true);
 ///

--- a/llvm/call_site_value.mbt
+++ b/llvm/call_site_value.mbt
@@ -25,7 +25,7 @@ pub fn CallSiteValue::as_value_ref(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -51,7 +51,7 @@ pub fn CallSiteValue::set_tail_call(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -76,7 +76,7 @@ pub fn CallSiteValue::is_tail_call(self : CallSiteValue) -> Bool {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -102,7 +102,7 @@ pub fn CallSiteValue::get_tail_call_kind(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -129,7 +129,7 @@ pub fn CallSiteValue::set_tail_call_kind(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -160,7 +160,7 @@ pub fn CallSiteValue::try_as_basic_value(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -194,7 +194,7 @@ pub fn CallSiteValue::add_attribute(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -221,7 +221,7 @@ pub fn CallSiteValue::get_called_fn_value(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -255,7 +255,7 @@ pub fn CallSiteValue::count_attributes(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip skip
+/// ```moonbit skip
 /// let context = Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -291,7 +291,7 @@ pub fn CallSiteValue::count_attributes(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -329,7 +329,7 @@ pub fn CallSiteValue::get_enum_attribute(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -367,7 +367,7 @@ pub fn CallSiteValue::get_string_attribute(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -404,7 +404,7 @@ pub fn CallSiteValue::remove_enum_attribute(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -441,7 +441,7 @@ pub fn CallSiteValue::remove_string_attribute(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -466,7 +466,7 @@ pub fn CallSiteValue::count_arguments(self : CallSiteValue) -> UInt {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -489,7 +489,7 @@ pub fn CallSiteValue::get_call_convention(self : CallSiteValue) -> UInt {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");


### PR DESCRIPTION
## Summary
- enable runnable examples in `ArrayValue`
- unskip several `CallSiteValue` examples

## Testing
- `moon test --target native` *(fails: llvm-c headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a535ccc54833184f731478ea56821