### PR TITLE
Enable simple doc tests

### DIFF
--- a/llvm/float_type.mbt
+++ b/llvm/float_type.mbt
@@ -32,7 +32,7 @@ pub fn FloatType::as_type_ref(self : FloatType) -> @unsafe.LLVMTypeRef {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let f32_type = context.f32_type();
 /// let i32_type = context.i32_type();
@@ -51,7 +51,7 @@ pub fn FloatType::fn_type(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let f32_type = context.f32_type();
 /// let array_type = f32_type.array_type(16);
@@ -65,7 +65,7 @@ pub fn FloatType::array_type(self : FloatType, size : UInt) -> ArrayType {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let f32_type = context.f32_type();
 /// let vector_type = f32_type.vec_type(16);
@@ -128,11 +128,11 @@ pub fn FloatType::const_float_from_string(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let f64_type = context.f64_type();
 /// let f64_zero = f64_type.const_zero();
-/// inspect(f64_zero, content="double 0.0")
+/// inspect(f64_zero, content="double 0.000000e+00")
 /// ```
 pub fn FloatType::const_zero(self : FloatType) -> FloatValue {
   FloatValue::new(self.ty.const_zero())
@@ -177,7 +177,7 @@ pub fn FloatType::get_alignment(self : FloatType) -> IntValue {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let f64_type = context.f64_type();
 /// let f64_ctx = f64_type.get_context();

--- a/llvm/float_value.mbt
+++ b/llvm/float_value.mbt
@@ -30,7 +30,7 @@ pub fn FloatValue::as_value_ref(self : FloatValue) -> @unsafe.LLVMValueRef {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create()
 /// let lmodule = context.create_module("demo")
 /// let f64_ty = context.f64_type()
@@ -57,7 +57,7 @@ pub fn FloatValue::get_name(self : FloatValue) -> String {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create()
 /// let lmodule = context.create_module("demo")
 /// let f64_ty = context.f64_type()
@@ -83,10 +83,10 @@ pub fn FloatValue::set_name(self : FloatValue, name : String) -> Unit {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
-/// let f64_type = context.f64_type();
-/// let pi = f64_type.const_float(3.14);
+/// let f32_type = context.f32_type();
+/// let pi = f32_type.const_float(3.14);
 /// inspect(pi.get_type(), content="float");
 /// ```
 pub fn FloatValue::get_type(self : FloatValue) -> FloatType {
@@ -102,7 +102,7 @@ pub fn FloatValue::is_null(self : FloatValue) -> Bool {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let f64_type = context.f64_type();
 /// let undef = f64_type.get_undef();
@@ -128,7 +128,7 @@ pub fn FloatValue::as_instruction(self : FloatValue) -> InstructionValue? {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let f64_type = context.f64_type();
 /// let f64_val = f64_type.const_float(1.2);
@@ -144,7 +144,7 @@ pub fn FloatValue::is_const(self : FloatValue) -> Bool {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let f64_type = context.f64_type();
 /// let pi = f64_type.const_float(3.14);


### PR DESCRIPTION
## Summary
- turn on a few previously skipped `moonbit` code examples
- adjust output expectations for zero constant
- use f32 type in `FloatValue.get_type` example

## Testing
- `moon check --target native`
- `moon test --target native`


------
https://chatgpt.com/codex/tasks/task_e_685a5d9c78d08331b001f1f3d24729dc