### PR TITLE
Enable some doc tests

### DIFF
--- a/llvm/fn_value.mbt
+++ b/llvm/fn_value.mbt
@@ -30,7 +30,7 @@ pub fn FunctionValue::as_value_ref(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let lmodule = context.create_module("demo");
 /// let i32_ty = context.i32_type();
@@ -49,7 +49,7 @@ pub fn FunctionValue::get_linkage(self : FunctionValue) -> Linkage {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let lmodule = context.create_module("demo");
 /// let i32_ty = context.i32_type();
@@ -75,7 +75,7 @@ pub fn FunctionValue::set_linkage(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let lmodule = context.create_module("demo");
 /// let i32_ty = context.i32_type();
@@ -93,7 +93,7 @@ pub fn FunctionValue::is_null(self : FunctionValue) -> Bool {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let lmodule = context.create_module("demo");
 /// let i32_ty = context.i32_type();
@@ -135,7 +135,7 @@ pub fn FunctionValue::get_previous_function(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let lmodule = context.create_module("demo");
 /// let i32_ty = context.i32_type();
@@ -159,7 +159,7 @@ pub fn FunctionValue::get_first_param(self : FunctionValue) -> BasicValueEnum? {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let lmodule = context.create_module("demo");
 /// let i32_ty = context.i32_type();
@@ -222,7 +222,7 @@ pub fn FunctionValue::get_nth_param(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let lmodule = context.create_module("demo");
 /// let i32_ty = context.i32_type();
@@ -278,7 +278,7 @@ pub fn FunctionValue::get_params(self : FunctionValue) -> Array[BasicValueEnum] 
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let lmodule = context.create_module("demo");
 /// let i32_ty = context.i32_type();

--- a/llvm/scalable_vec_value.mbt
+++ b/llvm/scalable_vec_value.mbt
@@ -31,7 +31,7 @@ pub fn ScalableVectorValue::as_value_ref(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i8_type = context.i8_type();
 /// let i8_scalable_vec_type = i8_type.scalable_vec_type(3);


### PR DESCRIPTION
## Summary
- re-enable several documentation tests for `FunctionValue` examples
- enable a scalable vector value example

## Testing
- `moon test --target native`

------
https://chatgpt.com/codex/tasks/task_e_685a6828a5b08331bebd893d3bfca709