### PR TITLE
Enable more doc tests

### DIFF
--- a/llvm/arr_type.mbt
+++ b/llvm/arr_type.mbt
@@ -23,9 +23,9 @@ pub fn ArrayType::as_type_ref(self : ArrayType) -> @unsafe.LLVMTypeRef {
 
 ///| Gets the size of this `ArrayType`. Value may vary depending on the target architecture.
 ///
-/// ## Example (Not Tested)
+/// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let array_type = i32_type.array_type(8);
@@ -39,9 +39,9 @@ pub fn ArrayType::size_of(self : ArrayType) -> IntValue? {
 
 ///| Gets the alignment of this `ArrayType`. Value may vary depending on the target architecture.
 ///
-/// ## Example (Not Tested)
+/// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let array_type = i32_type.array_type(8);
@@ -69,9 +69,9 @@ pub fn ArrayType::is_sized(self : ArrayType) -> Bool {
 
 ///| Creates a `PointerType` with this `ArrayType` for its element type.
 ///
-/// ## Example (Not Tested)
+/// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let array_type = i32_type.array_type(8);
@@ -87,9 +87,9 @@ pub fn ArrayType::ptr_type(
 
 ///| Gets a reference to the `Context` this `ArrayType` was created in.
 ///
-/// ## Example (Not Tested)
+/// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let array_type = i32_type.array_type(8);
@@ -102,9 +102,9 @@ pub fn ArrayType::get_context(self : ArrayType) -> Context {
 
 ///| Creates a `FunctionType` with this `ArrayType` for its return type.
 ///
-/// ## Example (Not Tested)
+/// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let array_type = i32_type.array_type(8);
@@ -152,7 +152,7 @@ pub fn ArrayType::const_zero(self : ArrayType) -> ArrayValue {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let array_type = i32_type.array_type(8);
@@ -208,7 +208,7 @@ pub fn ArrayType::get_poison(self : ArrayType) -> ArrayValue {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let array_type = i32_type.array_type(8);

--- a/llvm/int_type.mbt
+++ b/llvm/int_type.mbt
@@ -25,7 +25,7 @@ pub fn IntType::as_type_ref(self : IntType) -> @unsafe.LLVMTypeRef {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create()
 /// let i32_type = context.i32_type()
 /// let i32_val = i32_type.const_int(42, sign_extend=false)
@@ -110,7 +110,7 @@ pub fn IntType::fn_type(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let array_type = i32_type.array_type(16);
@@ -124,7 +124,7 @@ pub fn IntType::array_type(self : IntType, size : UInt) -> ArrayType {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let vector_type = i32_type.vec_type(16);
@@ -204,7 +204,7 @@ pub fn IntType::get_alignment(self : IntType) -> IntValue {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let ptr_type = i32_type.ptr_type(AddressSpace::default());
@@ -223,7 +223,7 @@ pub fn IntType::ptr_type(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i32_width = i32_type.get_bit_width();

--- a/llvm/void_type.mbt
+++ b/llvm/void_type.mbt
@@ -40,7 +40,7 @@ pub fn VoidType::get_context(self : VoidType) -> Context {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let void_type = context.void_type();
 /// let i32_type = context.i32_type();
@@ -59,7 +59,7 @@ pub fn VoidType::fn_type(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let void_type = context.void_type();
 /// let void_align = void_type.get_alignment();


### PR DESCRIPTION
## Summary
- unskip several simple doctests in array and int types and void type
- keep tests passing with updated examples

## Testing
- `moon check --target native`
- `moon test --target native`

------
https://chatgpt.com/codex/tasks/task_e_685a6f680ae8833182e8a1028524f7b6