### PR TITLE
Enable selected doc tests

### DIFF
--- a/llvm/basic_block.mbt
+++ b/llvm/basic_block.mbt
@@ -29,7 +29,7 @@ pub fn BasicBlock::new(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let prog = context.create_module("my_module");
 /// let void_type = context.void_type();
@@ -52,7 +52,7 @@ pub fn BasicBlock::get_parent(self : BasicBlock) -> FunctionValue? {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let llvm_module = context.create_module("my_module");
 /// let void_type = context.void_type();
@@ -80,7 +80,7 @@ pub fn BasicBlock::get_previous_basic_block(self : BasicBlock) -> BasicBlock? {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let llvm_module = context.create_module("my_module");
 /// let void_type = context.void_type();
@@ -110,7 +110,7 @@ pub fn BasicBlock::get_next_basic_block(self : BasicBlock) -> BasicBlock? {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let llvm_module = context.create_module("my_module");
 /// let void_type = context.void_type();
@@ -169,7 +169,7 @@ pub fn BasicBlock::move_after(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_module");
@@ -195,7 +195,7 @@ pub fn BasicBlock::get_first_instruction(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_module");
@@ -219,7 +219,7 @@ pub fn BasicBlock::get_last_instruction(self : BasicBlock) -> InstructionValue? 
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let llvm_module = context.create_module("ret");
 /// let builder = context.create_builder();
@@ -355,7 +355,7 @@ pub fn BasicBlock::get_context(self : BasicBlock) -> Context {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let llvm_module = context.create_module("my_mod");
 /// let void_type = context.void_type();
@@ -373,7 +373,7 @@ pub fn BasicBlock::get_name(self : BasicBlock) -> String {
 ///
 /// ## Example
 /// 
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let lmodule = context.create_module("my_mod");
 /// let void_type = context.void_type();

--- a/llvm/fn_value.mbt
+++ b/llvm/fn_value.mbt
@@ -197,7 +197,7 @@ pub fn FunctionValue::get_last_basic_block(self : FunctionValue) -> BasicBlock? 
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = @llvm.Context::create();
 /// let lmodule = context.create_module("demo");
 /// let i32_ty = context.i32_type();
@@ -256,7 +256,7 @@ pub fn FunctionValue::get_basic_blocks(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = @llvm.Context::create();
 /// let lmodule = context.create_module("demo");
 /// let i32_ty = context.i32_type();


### PR DESCRIPTION
## Summary
- unskip several `BasicBlock` examples so they run as doc tests
- run failing docs as `skip (test failed)`
- mark failing `FunctionValue` docs as skipped

## Testing
- `moon test --target native`

------
https://chatgpt.com/codex/tasks/task_e_685b7577d39c833183cfbf5e2fa9e099