### PR TITLE
Enable basic doc tests

### DIFF
--- a/llvm/arr_value.mbt
+++ b/llvm/arr_value.mbt
@@ -91,7 +91,7 @@ pub fn ArrayValue::is_const(self : ArrayValue) -> Bool {
 ///
 /// # Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let s = context.const_string("my_string", false);
 ///
@@ -107,7 +107,7 @@ pub fn ArrayValue::is_const_string(self : ArrayValue) -> Bool {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let string = context.const_string("hello!", true);
 ///

--- a/llvm/fn_type.mbt
+++ b/llvm/fn_type.mbt
@@ -25,7 +25,7 @@ pub fn FunctionType::as_type_ref(self : FunctionType) -> @unsafe.LLVMTypeRef {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let fn_type = i32_type.fn_type([i32_type]);
@@ -43,7 +43,7 @@ pub fn FunctionType::ptr_type(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let fn_type = i32_type.fn_type([i32_type], is_var_arg=true);
@@ -57,7 +57,7 @@ pub fn FunctionType::is_var_arg(self : FunctionType) -> Bool {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let f64_type = context.f64_type();
@@ -76,7 +76,7 @@ pub fn FunctionType::get_param_types(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let f64_type = context.f64_type();
@@ -94,7 +94,7 @@ pub fn FunctionType::count_param_types(self : FunctionType) -> UInt {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let fn_type = i32_type.fn_type([i32_type]);
@@ -108,7 +108,7 @@ pub fn FunctionType::is_sized(self : FunctionType) -> Bool {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let fn_type = i32_type.fn_type([i32_type]);
@@ -123,7 +123,7 @@ pub fn FunctionType::get_context(self : FunctionType) -> Context {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let f64_type = context.f64_type();

--- a/llvm/struct_value.mbt
+++ b/llvm/struct_value.mbt
@@ -27,7 +27,7 @@ pub fn StructValue::as_value_ref(self : StructValue) -> @unsafe.LLVMValueRef {
 
 ///| Gets the value of a field belonging to this `StructValue`.
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i8_type = context.i8_type();
@@ -85,7 +85,7 @@ pub fn StructValue::set_field_at_index(
 
 ///| Counts the number of fields.
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i8_type = context.i8_type();
@@ -146,7 +146,7 @@ pub fn StructValue::replace_all_uses_with(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i64_type = context.i64_type();
 /// let i64_val = i64_type.const_int(23, sign_extend=false);


### PR DESCRIPTION
## Summary
- run more code examples for array, struct, and function type values
- keep a failing function return type example skipped

## Testing
- `source agent_env.sh`
- `moon test --target native`

------
https://chatgpt.com/codex/tasks/task_e_685b95e66570833189e804d5f077f2b1