### PR TITLE
Enable some doc tests

### DIFF
--- a/llvm/attributes.mbt
+++ b/llvm/attributes.mbt
@@ -19,7 +19,7 @@ pub fn Attribute::as_attr_ref(self : Attribute) -> @unsafe.LLVMAttributeRef {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let enum_attribute = context.create_enum_attribute(0, 10);
 ///
@@ -33,7 +33,7 @@ pub fn Attribute::is_enum(self : Attribute) -> Bool {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let string_attribute = context.create_string_attribute("my_key_123", "my_val");
 ///
@@ -47,7 +47,7 @@ pub fn Attribute::is_string(self : Attribute) -> Bool {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let kind_id = Attribute::get_named_enum_kind_id("sret");
 /// let type_attribute = context.create_type_attribute(
@@ -65,7 +65,7 @@ pub fn Attribute::is_type(self : Attribute) -> Bool {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// // This kind id doesn't exist:
 /// assert_eq(Attribute::get_named_enum_kind_id("foobar"), 0);
 ///
@@ -81,7 +81,7 @@ pub fn Attribute::get_named_enum_kind_id(name : String) -> UInt {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let enum_attribute = context.create_enum_attribute(0, 10);
 ///
@@ -90,7 +90,7 @@ pub fn Attribute::get_named_enum_kind_id(name : String) -> UInt {
 ///
 /// This function also works for type `Attribute`s.
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let kind_id = Attribute::get_named_enum_kind_id("sret");
 /// let any_type = context.i32_type().as_any_type_enum();

--- a/llvm/struct_type.mbt
+++ b/llvm/struct_type.mbt
@@ -25,7 +25,7 @@ pub fn StructType::as_type_ref(self : StructType) -> @unsafe.LLVMTypeRef {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i64_type = context.i64_type();
@@ -68,7 +68,7 @@ pub fn StructType::const_zero(self : StructType) -> StructValue {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i64_type = context.i64_type();
@@ -89,7 +89,7 @@ pub fn StructType::size_of(self : StructType) -> IntValue? {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i64_type = context.i64_type();
@@ -106,7 +106,7 @@ pub fn StructType::is_sized(self : StructType) -> Bool {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i64_type = context.i64_type();


### PR DESCRIPTION
## Summary
- unskip a few simple documentation tests in `attributes.mbt` and `struct_type.mbt`
- mark failing enum kind test as skipped with reason

## Testing
- `moon check --target native`
- `moon test --target native`

------
https://chatgpt.com/codex/tasks/task_e_685bc14136f88331baf261384bced4e6