### PR TITLE
Enable passing doctests

### DIFF
--- a/llvm/basic_block.mbt
+++ b/llvm/basic_block.mbt
@@ -258,7 +258,7 @@ pub fn BasicBlock::get_instruction_with_name(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_module");
@@ -285,7 +285,7 @@ pub fn BasicBlock::get_terminator(self : BasicBlock) -> InstructionValue? {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let llvm_module = context.create_module("my_module");
 /// let void_type = context.void_type();
@@ -311,7 +311,7 @@ pub fn remove_from_function(self : BasicBlock) -> Unit raise MoonllvmError {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let llvm_module = context.create_module("my_module");
 /// let void_type = context.void_type();
@@ -333,7 +333,7 @@ pub fn BasicBlock::delete(self : BasicBlock) -> Unit raise MoonllvmError {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let llvm_module = context.create_module("my_module");
 /// let void_type = context.void_type();
@@ -392,7 +392,7 @@ pub fn BasicBlock::set_name(self : BasicBlock, name : String) -> Unit {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -424,7 +424,7 @@ pub fn BasicBlock::replace_all_uses_with(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let llvm_module = context.create_module("ivs");
 /// let builder = context.create_builder();
@@ -452,7 +452,7 @@ pub fn BasicBlock::get_first_use(self : BasicBlock) -> BasicValueUse? {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let llvm_module = context.create_module("my_mod");
 /// let void_type = context.void_type();

--- a/llvm/call_site_value.mbt
+++ b/llvm/call_site_value.mbt
@@ -25,7 +25,7 @@ pub fn CallSiteValue::as_value_ref(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -51,7 +51,7 @@ pub fn CallSiteValue::set_tail_call(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -76,7 +76,7 @@ pub fn CallSiteValue::is_tail_call(self : CallSiteValue) -> Bool {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -102,7 +102,7 @@ pub fn CallSiteValue::get_tail_call_kind(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -129,7 +129,7 @@ pub fn CallSiteValue::set_tail_call_kind(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -160,7 +160,7 @@ pub fn CallSiteValue::try_as_basic_value(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -194,7 +194,7 @@ pub fn CallSiteValue::add_attribute(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -221,7 +221,7 @@ pub fn CallSiteValue::get_called_fn_value(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -291,7 +291,7 @@ pub fn CallSiteValue::count_attributes(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -329,7 +329,7 @@ pub fn CallSiteValue::get_enum_attribute(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -367,7 +367,7 @@ pub fn CallSiteValue::get_string_attribute(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -404,7 +404,7 @@ pub fn CallSiteValue::remove_enum_attribute(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -441,7 +441,7 @@ pub fn CallSiteValue::remove_string_attribute(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -466,7 +466,7 @@ pub fn CallSiteValue::count_arguments(self : CallSiteValue) -> UInt {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");
@@ -489,7 +489,7 @@ pub fn CallSiteValue::get_call_convention(self : CallSiteValue) -> UInt {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = @llvm.Context::create();
 /// let builder = context.create_builder();
 /// let llvm_module = context.create_module("my_mod");

--- a/llvm/context.mbt
+++ b/llvm/context.mbt
@@ -482,7 +482,7 @@ pub fn Context::prepend_basic_block(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let i8_type = context.i8_type();
 /// let i8_two = i8_type.const_int(2, sign_extend=false);
@@ -518,7 +518,7 @@ pub fn Context::metadata_node(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let md_string = context.metadata_string("Floats are awesome!");
 /// let f32_type = context.f32_type();
@@ -565,7 +565,7 @@ pub fn Context::get_kind_id(self : Context, key : String) -> UInt {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let enum_attribute = context.create_enum_attribute(0, 10);
 ///
@@ -588,7 +588,7 @@ pub fn Context::create_enum_attribute(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let string_attribute = context.create_string_attribute("my_key_123", "my_val");
 ///

--- a/llvm/inst_value.mbt
+++ b/llvm/inst_value.mbt
@@ -409,7 +409,7 @@ pub fn InstructionValue::set_atomic_ordering(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let llvm_module = context.create_module("ivs");
 /// let builder = context.create_builder();
@@ -466,7 +466,7 @@ pub fn InstructionValue::get_num_operands(self : InstructionValue) -> UInt {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let llvm_module = context.create_module("ivs");
 /// let builder = context.create_builder();


### PR DESCRIPTION
## Summary
- switch a selection of doctests from `moonbit skip` to `moonbit`
- mark failing doctests as `moonbit skip (test failed)`

## Testing
- `moon check --target native`
- `moon test --target native`

------
https://chatgpt.com/codex/tasks/task_e_685bc14136f88331baf261384bced4e6