### PR TITLE
enable struct type doctests

### DIFF
--- a/llvm/struct_type.mbt
+++ b/llvm/struct_type.mbt
@@ -123,7 +123,7 @@ pub fn StructType::get_alignment(self : StructType) -> IntValue {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i64_type = context.i64_type();
@@ -146,7 +146,7 @@ pub fn StructType::get_name(self : StructType) -> String {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i64_type = context.i64_type();
@@ -166,7 +166,7 @@ pub fn StructType::fn_type(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i64_type = context.i64_type();
@@ -182,7 +182,7 @@ pub fn StructType::array_type(self : StructType, size : UInt) -> ArrayType {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i64_type = context.i64_type();
@@ -203,7 +203,7 @@ pub fn StructType::ptr_type(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i64_type = context.i64_type();
@@ -218,7 +218,7 @@ pub fn StructType::is_packed(self : StructType) -> Bool {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let struct_ty = context.opaque_struct_type("opaque_struct");
 /// assert_true(struct_ty.is_opaque())
@@ -231,7 +231,7 @@ pub fn StructType::is_opaque(self : StructType) -> Bool {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i64_type = context.i64_type();
@@ -247,7 +247,7 @@ pub fn StructType::count_fields(self : StructType) -> UInt {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i64_type = context.i64_type();
@@ -265,7 +265,7 @@ pub fn StructType::get_field_types(self : StructType) -> Array[BasicTypeEnum] {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i64_type = context.i64_type();
@@ -281,7 +281,7 @@ pub fn StructType::get_undef(self : StructType) -> StructValue {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let i64_type = context.i64_type();
@@ -301,7 +301,7 @@ pub fn StructType::get_poison(self : StructType) -> StructValue {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let opaque_struct = context.opaque_struct_type("opaque_struct");
 /// assert_true(opaque_struct.is_opaque())
@@ -326,7 +326,7 @@ pub fn StructType::set_body(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i32_type = context.i32_type();
 /// let struct_type = context.struct_type([i32_type]);


### PR DESCRIPTION
## Summary
- run several examples in `struct_type.mbt`
- keep failing examples skipped with annotation

## Testing
- `moon test --target native`
- `moon check --target native`


------
https://chatgpt.com/codex/tasks/task_e_685cea9e24048331a6f7513a8ed4cf24