### PR TITLE
Enable selected doc tests

### DIFF
--- a/llvm/attributes.mbt
+++ b/llvm/attributes.mbt
@@ -118,7 +118,7 @@ pub fn Attribute::get_enum_kind_id_is_valid(self : Attribute) -> Bool {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// assert_eq(Attribute::get_last_enum_kind_id(), 56);
 /// ```
 pub fn Attribute::get_last_enum_kind_id() -> UInt {
@@ -129,7 +129,7 @@ pub fn Attribute::get_last_enum_kind_id() -> UInt {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let enum_attribute = context.create_enum_attribute(0, 10);
 ///
@@ -147,7 +147,7 @@ pub fn Attribute::get_enum_value(self : Attribute) -> UInt64 {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let string_attribute = context.create_string_attribute("my_key", "my_val");
 ///
@@ -164,7 +164,7 @@ pub fn Attribute::get_string_kind_id(self : Attribute) -> String {
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let string_attribute = context.create_string_attribute("my_key", "my_val");
 ///
@@ -181,7 +181,7 @@ pub fn Attribute::get_string_value(self : Attribute) -> String {
 ///
 /// # Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit skip (test failed)
 /// let context = Context::create();
 /// let kind_id = Attribute::get_named_enum_kind_id("sret");
 /// let any_type = context.i32_type().as_any_type_enum();

--- a/llvm/builder.mbt
+++ b/llvm/builder.mbt
@@ -224,7 +224,7 @@ pub fn Builder::build_direct_call(
 ///
 /// ## Example (Not Tested)
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let llvm_module = context.create_module("call_with_op_bundles");
 /// let builder = context.create_builder();


### PR DESCRIPTION
## Summary
- remove skip marker from two attribute doc tests and builder operand bundle example
- mark failing attribute examples as skipped with failure note

## Testing
- `moon test --target native`

------
https://chatgpt.com/codex/tasks/task_e_685cf868823483319e5ac7d7398dba9a